### PR TITLE
Add ability to run python modules

### DIFF
--- a/app/Library/Config.cs
+++ b/app/Library/Config.cs
@@ -1,7 +1,14 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Configuration;
 
 namespace Library
 {
+    public enum PythonMode
+    {
+        Script,
+        Module
+    }
+
     public class Config
     {
         public static int RunSqlTimeout
@@ -10,6 +17,16 @@ namespace Library
             {
                 var configTimeout = ConfigurationManager.AppSettings["RunSqlTimeout"];
                 return configTimeout != null ? int.Parse(configTimeout) : 30;
+            }
+        }
+
+        public static PythonMode PythonMode
+        {
+            get
+            {
+                var configMode = ConfigurationManager.AppSettings["PythonMode"];
+                return configMode != null ? (PythonMode)Enum.Parse(typeof(PythonMode), configMode, true)
+                    : PythonMode.Script;
             }
         }
     }

--- a/app/Library/Scripts/Tasks/GetScripts.cs
+++ b/app/Library/Scripts/Tasks/GetScripts.cs
@@ -51,6 +51,11 @@ namespace Library.Scripts.Tasks
                     fileQualifies = fileSearch.IsMatch(whitelist);
                 }
 
+                if (fileQualifies && Config.PythonMode == PythonMode.Module)
+                {
+                    fileQualifies = !(fileNameWithoutPath.StartsWith("__") && fileNameWithoutPath.EndsWith("__.py", StringComparison.OrdinalIgnoreCase));
+                }
+
                 if (fileQualifies)
                 {
                     var match = Regex.Match(fileNameWithoutPath, versionedPattern);

--- a/app/Library/Scripts/Tasks/RunScripts.cs
+++ b/app/Library/Scripts/Tasks/RunScripts.cs
@@ -33,7 +33,7 @@ namespace Library.Scripts.Tasks
                 else if (String.Compare(extension, ".py", StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     RunProcess.In.FileName = "python";
-                    RunProcess.In.Arguments = script.FileName;
+                    RunProcess.In.Arguments = GetPythonArguments(script.FileName);
                     RunProcess.Execute();
                 }
                 else
@@ -41,6 +41,13 @@ namespace Library.Scripts.Tasks
                     throw new RunException(String.Format("Don't know how to run {0}.", fileName));
                 }
             }
+        }
+
+        private string GetPythonArguments(string fileName)
+        {
+            if (Config.PythonMode == PythonMode.Script) return fileName;
+            var extension = Path.GetExtension(fileName);
+            return String.Format("-m {0}", fileName.Replace("\\", ".").Substring(0, fileName.Length - extension.Length));
         }
     }
 }

--- a/app/Library/Timestamp/Tasks/GetFiles.cs
+++ b/app/Library/Timestamp/Tasks/GetFiles.cs
@@ -31,6 +31,9 @@ namespace Library.Timestamp.Tasks
                 var directoryName = Path.GetDirectoryName(file);
                 var isTimestamped = Regex.IsMatch(fileName, timestampPattern, RegexOptions.None);
 
+                if (Config.PythonMode == PythonMode.Module && fileName.StartsWith("__") && file.EndsWith("__.py", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
                 var timestampFile = new TimestampFile
                 {
                     FileName = fileName,


### PR DESCRIPTION
Currently please only executes python as standalone scripts.  If I want to import other parts of my library as-is, I have to add the other section to my PYTHONPATH.  Not ideal.

Enter running as modules (with the `-m` flag).  Set the configuration value `PythonMode` in your `please.exe.config` and magically `__init__.py` files are ignored and paths are converted to dot notation.  And I can import relative!
